### PR TITLE
ci(travis): ignore engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ node_js:
   - 8
   - 6
 
-env:
-  global:
-  # oracle info
-    # - NODE_ORACLEDB_HOST: localhost
+before_install:
+  - yarn config set ignore-engines true
 
 script:
   - yarn run test
@@ -20,23 +18,7 @@ notifications:
   email:
     on_failure: change
 
-# before_install:
-#   - |
-#     mkdir -p /opt/oracle &&
-#     cd /opt/oracle &&
-#     wget https://s3.amazonaws.com/sequelize/instantclient-basic-linux.x64-12.1.0.2.0.zip &&
-#     wget https://s3.amazonaws.com/sequelize/instantclient-sdk-linux.x64-12.1.0.2.0.zip &&
-#     unzip instantclient-basic-linux.x64-12.1.0.2.0.zip &&
-#     unzip instantclient-sdk-linux.x64-12.1.0.2.0.zip &&
-#     mv instantclient_12_1 instantclient &&
-#     cd instantclient &&
-#     ln -s libclntsh.so.12.1 libclntsh.so &&
-#     export LD_LIBRARY_PATH=/opt/oracle/instantclient:$LD_LIBRARY_PATH &&
-#     cd $TRAVIS_BUILD_DIR;
-
 after_success: 'yarn run reportcoverage'
 
 cache:
   yarn: true
-  directories:
-    - node_modules


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:  add ignore-engines true configuration for yarn to the travis-ci builds

<!-- Why are these changes necessary? -->
**Why**: dependency bunyan-sentry-stream@1.2.0 has set node engine = 4.8.4.  this prevents it from being installed by yarn on any version of nodejs except for 4.8.4, meaning versions 6.x and 8.x fail. for some reason, yarn wasn't reporting this error before, even though it's documentation said it would.

<!-- How were these changes implemented? -->
**How**:  added `yarn config set ignore-engines true` to the `before_install` step in .travis.yml

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
This is needed as a workaround until transcovo/bunyan-sentry-stream#11 is merged.
closes #55 