### PR TITLE
fix(package): update sequelize to version 4.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "restify": "6.3.4",
     "restify-cors-middleware": "1.0.1",
     "restify-errors": "5.0.0",
-    "sequelize": "4.23.1"
+    "sequelize": "4.26.0"
   },
   "devDependencies": {
     "commitizen": "2.9.6",


### PR DESCRIPTION
Closes #171
